### PR TITLE
potential fix for issue #35

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,8 @@ Cron job `RunCronTasks` started every 4 minutes by the scheduler will spawn a se
 
 ## Changelog
 
+2021-xx-xx - 3.0.0 Drop Python2 compatibility
+                   FIX "cron_remote_manager disable ALL".
 2020-05-25 - 2.1.0 Python 3 + Django 2 compatibility.
 2020-04-30 - 2.0.1 Fix for sentry-sdk.
 2020-04-23 - 2.0.0 Replace raven with sentry-sdk.

--- a/cronman/utils.py
+++ b/cronman/utils.py
@@ -13,7 +13,13 @@ import subprocess
 import sys
 from importlib import import_module
 
-from django.utils.encoding import force_text
+from django import VERSION
+
+if VERSION[0] >= 3:
+    from django.utils.encoding import force_str as force_text
+else:
+    from django.utils.encoding import force_text
+
 from django.utils.functional import cached_property
 
 from dateutil.parser import parse as dateutil_parse

--- a/cronman/worker/process_manager.py
+++ b/cronman/worker/process_manager.py
@@ -10,7 +10,12 @@ import os
 import signal
 import subprocess
 
-from django.utils.encoding import force_text
+from django import VERSION
+
+if VERSION[0] >= 3:
+    from django.utils.encoding import force_str as force_text
+else:
+    from django.utils.encoding import force_text
 
 logger = logging.getLogger("cronman.command.cron_worker")
 

--- a/cronman/worker/worker_file.py
+++ b/cronman/worker/worker_file.py
@@ -6,7 +6,13 @@ from __future__ import unicode_literals
 import hashlib
 import os
 
-from django.utils.encoding import force_bytes, force_text
+from django import VERSION
+
+if VERSION[0] >= 3:
+    from django.utils.encoding import force_str as force_text
+else:
+    from django.utils.encoding import force_text
+
 from django.utils.functional import cached_property
 
 from cronman.spawner import CronSpawner

--- a/cronman/worker/worker_file.py
+++ b/cronman/worker/worker_file.py
@@ -9,9 +9,9 @@ import os
 from django import VERSION
 
 if VERSION[0] >= 3:
-    from django.utils.encoding import force_str as force_text
+    from django.utils.encoding import force_str as force_text, force_bytes
 else:
-    from django.utils.encoding import force_text
+    from django.utils.encoding import force_text, force_bytes
 
 from django.utils.functional import cached_property
 


### PR DESCRIPTION
This is a potential fix for #35 as it would conditionally import `force_str` for versions of Django 3+ but use `force_text` for older versions. 

I tried to test it locally, but was not able to. I looked for a Contribution guide but wasn't able to find one. If there's something else I can do to help get this implemented, please let me know and I'll do what I can. This looks like a very nice project. 

Thanks!